### PR TITLE
⏰ Change cron schedule because timezones

### DIFF
--- a/.github/workflows/pagerduty-rota-notifier.yml
+++ b/.github/workflows/pagerduty-rota-notifier.yml
@@ -3,7 +3,8 @@ name: 📟 PagerDuty Rota Notifier
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Monday-Friday at 09:00 UTC
+    # - cron: "0 9 * * 1-5" # Monday-Friday at 09:00 UTC
+    - cron: "0 8 * * 1-5" # Monday-Friday at 08:00 UTC, or 09:00 BST
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Proposed Changes

- The clocks went forward, so this runs at 10, it should run at 9!

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>