### PR TITLE
Update slack notif

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ def get_slack_user_id():
     digital_suff = "@justice.gov.uk"
     justice_suff = "@digital.justice.gov.uk"
 
-    # defines ids for both digital and justice email addresses
+    # create digital and justice email addresses for user
     justice_email = user_email_pref + digital_suff
     digital_email = user_email_pref + justice_suff
 


### PR DESCRIPTION
If a user has a Slack account linked to their `digital.justice.gov.uk` email, but their PagerDuty account is linked to their `justice.gov.uk` email, the user will not be correctly tagged in the Slack message and they won't be notified.

Some users have 2 Slack accounts; one linked to their `justice.gov.uk` email and another to their `digital.justice.gov.uk` email. If their PagerDuty email matches their unused Slack account, the unused account will be tagged and the intended user will not receive a notification.

This PR handles the case where a user's Slack and PagerDuty account email addresses don't match.

Also fixes a minor typo.