### PR TITLE
🏎️ Set `strategy.fail-fast: false`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Initialise CodeQL
         id: initialise_codeql

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         id: dependency_review

--- a/.github/workflows/pagerduty-rota-notifier.yml
+++ b/.github/workflows/pagerduty-rota-notifier.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         include:
           - pagerduty-schedule-id: POE95CC # Analytical Platform
@@ -30,6 +31,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set Up uv
         id: setup_uv

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,6 +25,7 @@ jobs:
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Super-Linter

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,3 +33,4 @@ jobs:
         uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MULTI_STATUS: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+---
+name: 🌈 Zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set Up UV
+        id: setup_uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
+      - name: Zizmor
+        id: zizmor
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uvx zizmor --format sarif . > zizmor.sarif
+
+      - name: Upload SARIF
+        id: upload_sarif
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
## Proposed Changes

- Sets `strategy.fail-fast: false`
  - [Today's run](https://github.com/ministryofjustice/pagerduty-rota-notifier/actions/runs/14924358175) failed because [PAMEXM1](https://moj-digital-tools.pagerduty.com/schedules#PAMEXM1)'s current on-call user is inactive. This failure caused the rest of the workflows to exit before proper completion. They did run the script and notifications were sent, but the jobs were marked as skipped.
- Adds [Zizmor](https://docs.zizmor.sh/) workflow

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>