### PR TITLE
🙈 Exclude pre-commit configuration from prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-json
       - id: check-added-large-files
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: 39fdb480a06768cc41a84ef86959c07ff33091c4 # frozen: v8.28.0
+    rev: 39fdb480a06768cc41a84ef86959c07ff33091c4  # frozen: v8.28.0
     hooks:
       - id: gitleaks
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 69fa534d69454f44ddd4451b5e2da7a1c48e525b # frozen: v1.11.0
+    rev: 69fa534d69454f44ddd4451b5e2da7a1c48e525b  # frozen: v1.11.0
     hooks:
       - id: zizmor
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 4cbc74d53fe5634e58e0e65db7d28939c9cec3f7 # frozen: v0.12.7
+    rev: 4cbc74d53fe5634e58e0e65db7d28939c9cec3f7  # frozen: v0.12.7
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .devcontainer/devcontainer-lock.json
+.pre-commit-config.yaml


### PR DESCRIPTION
## Proposed Changes

- Excludes `.pre-commit-config.yaml` from prettier. 
  - Following the introduction of the pre-commit update workflow (https://github.com/ministryofjustice/pagerduty-rota-notifier/pull/81), the automatic change breaks prettier (https://github.com/ministryofjustice/pagerduty-rota-notifier/actions/runs/16824642136/job/47658205773)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>