### PR TITLE
🇬🇧 Enable `timezone`

### DIFF
--- a/.github/workflows/pagerduty-rota-notifier.yml
+++ b/.github/workflows/pagerduty-rota-notifier.yml
@@ -3,7 +3,7 @@ name: 📟 PagerDuty Rota Notifier
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5"
+    - cron: "0 8 * * 1-5"
       timezone: "Europe/London"
   workflow_dispatch:
 

--- a/.github/workflows/pagerduty-rota-notifier.yml
+++ b/.github/workflows/pagerduty-rota-notifier.yml
@@ -3,7 +3,8 @@ name: 📟 PagerDuty Rota Notifier
 
 on:
   schedule:
-    - cron: "0 7 * * 1-5" # Monday-Friday at 07:00 UTC
+    - cron: "0 9 * * 1-5"
+      timezone: "Europe/London"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Proposed Changes

- Adds `timezone` flag as per https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-timezone-support-for-scheduled-workflows

## Notes

Super-Linter is Currently failing on

```
GITHUB_ACTIONS:
  Error: -01 11:37:22 [ERROR]   Errors found in GITHUB_ACTIONS
  Error: -01 11:37:22 [ERROR]   Stdout contents for GITHUB_ACTIONS:
  ------
  .github/workflows/pagerduty-rota-notifier.yml:7:7: expected "cron" key for element of "schedule" section but got "timezone" [syntax-check]
    |
  7 |       timezone: "Europe/London"
    |       ^~~~~~~~~
  ------
```

We're currently using [v8.5.0](https://github.com/super-linter/super-linter/releases/tag/v8.5.0) of Super-Linter via ([ministryofjustice/analytical-platform-github-actions@v7.1.0](https://github.com/ministryofjustice/analytical-platform-github-actions/releases/tag/v7.1.0)) that ships with [`1.7.10` of `rhysd/actionlint`](https://github.com/super-linter/super-linter/blob/61abc07d755095a68f4987d1c2c3d1d64408f1f9/Dockerfile#L23)

Support for `timezone` was added in https://github.com/rhysd/actionlint/pull/641, released in [v1.7.12](https://github.com/rhysd/actionlint/releases/tag/v1.7.12), and comes in [v8.6.0 of Super-Linter](https://github.com/super-linter/super-linter/blob/9e863354e3ff62e0727d37183162c4a88873df41/Dockerfile#L23)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>